### PR TITLE
feat: implemnt the contract for the yieldmaker vault

### DIFF
--- a/contracts/src/IStrategy.sol
+++ b/contracts/src/IStrategy.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IStrategy {
+    function invest(uint256 amount) external;
+    function withdraw(uint256 amount) external;
+    function totalAssets() external view returns (uint256);
+    function emergencyWithdraw() external;
+}

--- a/contracts/src/YieldmakerVault.sol
+++ b/contracts/src/YieldmakerVault.sol
@@ -5,3 +5,80 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+import "./IStrategy.sol";
+
+contract YieldmakerVault is ERC4626, Ownable {
+    IStrategy public strategy;
+    bool public paused;
+
+    // events
+     event StrategyUpdated(address indexed newStrategy);
+    event Paused(address account);
+    event Unpaused(address account);
+
+    // constructor
+
+    constructor(IERC20 _asset, address _strategy) 
+         ERC4626(_asset)
+        ERC20("Yieldmaker USDC", "yUSDC")
+        Ownable(msg.sender){
+            strategy = IStrategy(_strategy);
+
+        }
+
+
+    modifier whenNotPaused() {
+        require(!paused, "Vault is paused");
+        _;
+    }
+    
+
+    function setStrategy(address _newStrategy) external onlyOwner {
+        require(_newStrategy != address(0), "Invalid strategy");
+        strategy = IStrategy(_newStrategy);
+        emit StrategyUpdated(_newStrategy);
+    }
+
+    function pause() external onlyOwner {
+        paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() external onlyOwner {
+        paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        return strategy.totalAssets();
+    }
+
+    function deposit(uint256 assets, address receiver)
+        public
+        override
+        whenNotPaused
+        returns (uint256)
+    {
+        uint256 shares = super.deposit(assets, receiver);
+        IERC20(asset()).approve(address(strategy), assets);
+        strategy.invest(assets);
+        return shares;
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        override
+        whenNotPaused
+        returns (uint256)
+    {
+        strategy.withdraw(assets);
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    function emergencyWithdraw() external onlyOwner {
+        strategy.emergencyWithdraw();
+        paused = true;
+    }
+
+
+}


### PR DESCRIPTION
## PR Title
Add YieldmakerVault contract with ERC4626 vault + strategy integration

## PR Description
This PR introduces the YieldmakerVault contract, an ERC-4626 compliant vault that integrates with an external strategy contract (IStrategy). The vault allows users to deposit ERC20 assets (e.g., USDC) and automatically routes them into a yield-generating strategy.

The vault issues ERC4626-compliant “share tokens” (yUSDC) to represent user deposits, ensuring standardized interaction with DeFi protocols and frontends.

## Key Features

### ERC-4626 Vault Standard

- Inherits from OpenZeppelin’s ERC4626, enabling standardized deposit, withdrawal, and share accounting.
- Users deposit assets and receive yUSDC shares representing their share of the vault.
- Pluggable Strategy Architecture
- Uses the IStrategy interface to interact with external strategies.
- The strategy can be updated by the owner via setStrategy().
- Keeps the vault flexible: different strategies (Aave, Uniswap, Compound, etc.) can be plugged in without changing the vault logic.

### Pause / Unpause Functionality
- Owner can pause deposits/withdrawals in case of emergency.
- emergencyWithdraw() allows pulling all funds back from the strategy and pausing the vault.

### Events for Transparency
- StrategyUpdated(address) when a new strategy is set.
- Paused(address) / Unpaused(address) for vault state changes.

### Security Considerations

- Only the owner can update the strategy or trigger emergency withdrawals.
- Vault enforces whenNotPaused modifier on deposits/withdrawals.
- Approvals are handled explicitly before forwarding funds to the strategy.
